### PR TITLE
Add WASM target to produce mmg.js and mmg.wasm output files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,12 +28,18 @@ message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "Emscripten: ${EMSCRIPTEN_VERSION}")
 message(STATUS "")
 
-# Placeholder for future binding targets
-# The actual WASM bindings will be added in subsequent issues
-# Example:
-#   add_executable(mmg-wasm src/bindings.c)
-#   target_link_libraries(mmg-wasm PRIVATE libmmg_a)
-#   configure_wasm_target(mmg-wasm)
+# Create WASM target linking against mmg
+add_executable(mmg src/stub.c)
 
-message(STATUS "Configuration complete. mmg library will be built as a static library.")
-message(STATUS "WASM bindings will be added in subsequent development.")
+target_link_libraries(mmg PRIVATE libmmg_a)
+
+target_include_directories(mmg PRIVATE
+    ${mmg_BINARY_DIR}/include
+    ${mmg_SOURCE_DIR}/src
+)
+
+target_link_options(mmg PRIVATE
+    -sEXPORTED_FUNCTIONS=['_mmg_version','_mmgwasm_version','_mmg_test_init','_malloc','_free']
+)
+
+configure_wasm_target(mmg)

--- a/src/stub.c
+++ b/src/stub.c
@@ -1,0 +1,38 @@
+#include <emscripten.h>
+#include "mmg/mmg3d/libmmg3d.h"
+
+EMSCRIPTEN_KEEPALIVE
+const char* mmg_version(void) {
+    return MMG_VERSION_RELEASE;
+}
+
+EMSCRIPTEN_KEEPALIVE
+const char* mmgwasm_version(void) {
+    return "0.0.1";
+}
+
+EMSCRIPTEN_KEEPALIVE
+int mmg_test_init(void) {
+    MMG5_pMesh mesh = NULL;
+    MMG5_pSol sol = NULL;
+
+    int result = MMG3D_Init_mesh(
+        MMG5_ARG_start,
+        MMG5_ARG_ppMesh, &mesh,
+        MMG5_ARG_ppMet, &sol,
+        MMG5_ARG_end
+    );
+
+    if (result != 1 || mesh == NULL) return 0;
+
+    MMG3D_Init_parameters(mesh);
+
+    MMG3D_Free_all(
+        MMG5_ARG_start,
+        MMG5_ARG_ppMesh, &mesh,
+        MMG5_ARG_ppMet, &sol,
+        MMG5_ARG_end
+    );
+
+    return 1;
+}


### PR DESCRIPTION
## Summary
- Add minimal C stub (`src/stub.c`) that links against libmmg_a
- Export version and initialization test functions
- Configure CMake target to produce `build/dist/mmg.js` and `build/dist/mmg.wasm`

Closes #2

## Test plan
- [x] `bun run build` completes without errors
- [x] `build/dist/mmg.js` exists (24KB ES6 module)
- [x] `build/dist/mmg.wasm` exists (72KB, well under 5MB limit)
- [x] `mmg_version()` returns "5.8.0"
- [x] `mmgwasm_version()` returns "0.0.1"
- [x] `mmg_test_init()` returns 1 (success)