### PR TITLE
Add TypedArray ↔ WASM heap utilities

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export {
   type MeshSize,
   type IParamKey,
   type DParamKey,
+  type MMG3DModule,
 } from "./mmg3d";
 
 // Export memory utilities

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -136,7 +136,7 @@ export function toWasmUint32(module: WasmModule, data: Uint32Array): number {
     );
   }
 
-  // Copy data to WASM heap using a Uint32Array view on the heap buffer
+  // Copy data to WASM heap (create Uint32Array view since HEAPU32 may not be exported)
   const heapU32 = new Uint32Array(module.HEAPU8.buffer, ptr, data.length);
   heapU32.set(data);
   return ptr;

--- a/src/mmg3d.ts
+++ b/src/mmg3d.ts
@@ -5,6 +5,8 @@
  * Uses Emscripten's cwrap to call the C wrapper functions.
  */
 
+import type { WasmModule } from "./memory";
+
 /**
  * Integer parameters for MMG3D (matching MMG3D_Param enum in libmmg3d.h)
  */
@@ -75,7 +77,7 @@ export const MMG_RETURN_CODES = {
 } as const;
 
 /** Internal module interface (raw Emscripten functions) */
-interface MMG3DModule {
+export interface MMG3DModule extends WasmModule {
   _mmg3d_init(): number;
   _mmg3d_free(handle: number): number;
   _mmg3d_get_available_handles(): number;
@@ -145,11 +147,6 @@ interface MMG3DModule {
   _mmg3d_set_dparameter(handle: number, dparam: number, val: number): number;
   _mmg3d_remesh(handle: number): number;
   _mmg3d_free_array(ptr: number): void;
-  _malloc(size: number): number;
-  _free(ptr: number): void;
-  HEAPU8: Uint8Array;
-  HEAPF64: Float64Array;
-  HEAP32: Int32Array;
   getValue(ptr: number, type: string): number;
   setValue(ptr: number, value: number, type: string): void;
 }
@@ -166,11 +163,9 @@ export async function initMMG3D(): Promise<void> {
   }
 
   // Dynamic import of the Emscripten-generated module
-  // Note: Using build2 temporarily due to permission issues with build/
-  // Once permissions are fixed, rebuild to build/ and update this path
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore - Emscripten module doesn't have TypeScript declarations
-  const createModule = (await import("../build2/dist/mmg.js")).default;
+  const createModule = (await import("../build/dist/mmg.js")).default;
   module = (await createModule()) as MMG3DModule;
 }
 

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll } from "bun:test";
-import { initMMG3D, getWasmModule } from "../src/mmg3d";
+import { initMMG3D, getWasmModule, type MMG3DModule } from "../src/mmg3d";
 import {
   toWasmFloat64,
   toWasmInt32,
@@ -9,15 +9,14 @@ import {
   fromWasmUint32,
   freeWasmArray,
   getMemoryStats,
-  type WasmModule,
 } from "../src/memory";
 
 describe("Memory Utilities", () => {
-  let module: WasmModule;
+  let module: MMG3DModule;
 
   beforeAll(async () => {
     await initMMG3D();
-    module = getWasmModule() as WasmModule;
+    module = getWasmModule();
   });
 
   describe("toWasmFloat64", () => {


### PR DESCRIPTION
## Summary

- Implement standalone memory utility functions in `src/memory.ts` for safely transferring data between JavaScript TypedArrays and the WASM linear memory heap
- Export utilities from `src/index.ts` for public API access
- Add comprehensive test suite in `test/memory.test.ts` (23 tests)

## Functions Added

| Function | Description |
|----------|-------------|
| `toWasmFloat64()` | Copy Float64Array to WASM heap |
| `toWasmInt32()` | Copy Int32Array to WASM heap |
| `fromWasmFloat64()` | Copy Float64 data from WASM heap to new array |
| `fromWasmInt32()` | Copy Int32 data from WASM heap to new array |
| `freeWasmArray()` | Free allocated WASM memory (idempotent) |
| `getMemoryStats()` | Get memory statistics |

## Design Decisions

- Uses copies (not views) to prevent invalidation on heap growth
- `freeWasmArray(0)` is a no-op for safe idempotent cleanup patterns
- Empty arrays return pointer 0 (convention for null/empty)
- `WasmModule` interface allows reuse across MMG3D, MMGS, MMG2D

Closes #5

## Test plan

- [x] Type checking passes (`bun run typecheck`)
- [x] Lint/format passes (`bun run check`)
- [x] All 23 memory tests pass (`bun test test/memory.test.ts`)
- [x] Round-trip tests verify data integrity
- [x] Large array tests (100K elements) verify scalability