### PR TITLE
feat: Add Three.js integration utilities

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,8 +7,16 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.0",
         "@types/bun": "latest",
+        "@types/three": "^0.160.0",
+        "three": "^0.170.0",
         "typescript": "^5.6.0",
       },
+      "peerDependencies": {
+        "three": ">=0.150.0",
+      },
+      "optionalPeers": [
+        "three",
+      ],
     },
   },
   "packages": {
@@ -34,7 +42,19 @@
 
     "@types/node": ["@types/node@25.0.9", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw=="],
 
+    "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
+
+    "@types/three": ["@types/three@0.160.0", "", { "dependencies": { "@types/stats.js": "*", "@types/webxr": "*", "fflate": "~0.6.10", "meshoptimizer": "~0.18.1" } }, "sha512-jWlbUBovicUKaOYxzgkLlhkiEQJkhCVvg4W2IYD2trqD2om3VK4DGLpHH5zQHNr7RweZK/5re/4IVhbhvxbV9w=="],
+
+    "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
+
     "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
+
+    "fflate": ["fflate@0.6.10", "", {}, "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg=="],
+
+    "meshoptimizer": ["meshoptimizer@0.18.1", "", {}, "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw=="],
+
+    "three": ["three@0.170.0", "", {}, "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/package.json
+++ b/package.json
@@ -30,9 +30,19 @@
     "web:build": "cp build/dist/mmg.js build/dist/mmg.wasm web/ && cd web && bun run build",
     "web:preview": "cd web && bun run preview"
   },
+  "peerDependencies": {
+    "three": ">=0.150.0"
+  },
+  "peerDependenciesMeta": {
+    "three": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",
     "@types/bun": "latest",
+    "@types/three": "^0.160.0",
+    "three": "^0.170.0",
     "typescript": "^5.6.0"
   },
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,15 @@ export {
   type MemoryConfig,
 } from "./memory";
 
+// Export Three.js integration utilities
+export {
+  fromThreeGeometry,
+  toThreeGeometry,
+  toThreeGeometrySync,
+  type FromThreeOptions,
+  type ToThreeOptions,
+} from "./three";
+
 // Legacy interface (for backwards compatibility)
 export interface MmgModule {
   mmg_version(): string;

--- a/src/three/index.ts
+++ b/src/three/index.ts
@@ -1,0 +1,339 @@
+/**
+ * Three.js integration utilities for mmg-wasm
+ *
+ * Provides conversion functions between Three.js BufferGeometry and mmg-wasm Mesh.
+ * Three.js is an optional peer dependency - these utilities only work when Three.js is installed.
+ *
+ * @example
+ * ```typescript
+ * import { fromThreeGeometry, toThreeGeometry } from 'mmg-wasm/three';
+ * import * as THREE from 'three';
+ *
+ * // Convert Three.js geometry to mmg-wasm Mesh
+ * const geometry = new THREE.BoxGeometry(1, 1, 1);
+ * const mesh = fromThreeGeometry(geometry);
+ *
+ * // Remesh
+ * const result = await mesh.remesh({ hmax: 0.1 });
+ *
+ * // Convert back to Three.js
+ * const newGeometry = await toThreeGeometry(result.mesh);
+ * ```
+ *
+ * @module three
+ */
+
+import type { BufferAttribute, BufferGeometry } from "three";
+import { Mesh, MeshType } from "../mesh";
+
+/**
+ * Options for converting Three.js BufferGeometry to mmg-wasm Mesh
+ */
+export interface FromThreeOptions {
+  /**
+   * Force a specific mesh type instead of auto-detecting.
+   * By default, 3D geometries are treated as surface meshes (MeshS).
+   */
+  type?: MeshType;
+}
+
+/**
+ * Options for converting mmg-wasm Mesh to Three.js BufferGeometry
+ */
+export interface ToThreeOptions {
+  /**
+   * Compute vertex normals after conversion.
+   * @default true
+   */
+  computeNormals?: boolean;
+}
+
+/**
+ * Convert a Three.js BufferGeometry to an mmg-wasm Mesh
+ *
+ * This function extracts vertex positions and face indices from a BufferGeometry
+ * and creates an mmg-wasm Mesh suitable for remeshing operations.
+ *
+ * @param geometry - The Three.js BufferGeometry to convert
+ * @param options - Conversion options
+ * @returns A new mmg-wasm Mesh instance
+ * @throws Error if the geometry has no position attribute
+ * @throws Error if the geometry has no faces (neither indexed nor with enough vertices)
+ *
+ * @example
+ * ```typescript
+ * import { fromThreeGeometry } from 'mmg-wasm/three';
+ * import * as THREE from 'three';
+ *
+ * const boxGeometry = new THREE.BoxGeometry(1, 1, 1);
+ * const mesh = fromThreeGeometry(boxGeometry);
+ *
+ * // Can now remesh
+ * const result = await mesh.remesh({ hmax: 0.1 });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Force 2D mesh type for flat geometries
+ * const planeGeometry = new THREE.PlaneGeometry(1, 1);
+ * const mesh = fromThreeGeometry(planeGeometry, { type: MeshType.Mesh2D });
+ * ```
+ */
+export function fromThreeGeometry(
+  geometry: BufferGeometry,
+  options: FromThreeOptions = {},
+): Mesh {
+  const positions = geometry.attributes.position;
+  if (!positions) {
+    throw new Error("Geometry must have a position attribute");
+  }
+
+  const itemSize = positions.itemSize;
+  if (itemSize !== 3 && itemSize !== 2) {
+    throw new Error(
+      `Position attribute must have itemSize 2 or 3, got ${itemSize}`,
+    );
+  }
+
+  const positionCount = positions.count;
+  if (positionCount < 3) {
+    throw new Error(
+      `Geometry must have at least 3 vertices, got ${positionCount}`,
+    );
+  }
+
+  // Extract vertices as Float64Array
+  // Convert from Float32 (WebGL standard) to Float64 (mmg requirement)
+  // Use getX/getY/getZ methods which work for both BufferAttribute and InterleavedBufferAttribute
+  const vertices = new Float64Array(positionCount * itemSize);
+  const posAttr = positions as BufferAttribute;
+  for (let i = 0; i < positionCount; i++) {
+    vertices[i * itemSize] = posAttr.getX(i);
+    vertices[i * itemSize + 1] = posAttr.getY(i);
+    if (itemSize === 3) {
+      vertices[i * itemSize + 2] = posAttr.getZ(i);
+    }
+  }
+
+  // Extract indices
+  let cells: Int32Array;
+  if (geometry.index) {
+    // Indexed geometry: convert to 1-indexed for MMG
+    const indexArray = geometry.index.array;
+    const indexCount = geometry.index.count;
+
+    if (indexCount < 3 || indexCount % 3 !== 0) {
+      throw new Error(
+        `Geometry index count must be divisible by 3, got ${indexCount}`,
+      );
+    }
+
+    cells = new Int32Array(indexCount);
+    for (let i = 0; i < indexCount; i++) {
+      // Convert from 0-indexed (Three.js) to 1-indexed (MMG)
+      cells[i] = indexArray[i] + 1;
+    }
+  } else {
+    // Non-indexed geometry: every 3 vertices form a triangle
+    if (positionCount % 3 !== 0) {
+      throw new Error(
+        `Non-indexed geometry vertex count must be divisible by 3, got ${positionCount}`,
+      );
+    }
+
+    cells = new Int32Array(positionCount);
+    for (let i = 0; i < positionCount; i++) {
+      // Convert from 0-indexed to 1-indexed
+      cells[i] = i + 1;
+    }
+  }
+
+  // Determine mesh type
+  let type = options.type;
+  if (!type) {
+    if (itemSize === 2) {
+      type = MeshType.Mesh2D;
+    } else {
+      // 3D geometry - default to surface mesh
+      type = MeshType.MeshS;
+    }
+  }
+
+  return new Mesh({
+    vertices,
+    cells,
+    type,
+  });
+}
+
+/**
+ * Convert an mmg-wasm Mesh to a Three.js BufferGeometry
+ *
+ * This function creates a new BufferGeometry from the mesh's vertices and cells.
+ * For volumetric meshes (Mesh3D), the boundary faces are extracted for visualization.
+ *
+ * @param mesh - The mmg-wasm Mesh to convert
+ * @param options - Conversion options
+ * @returns A Promise resolving to a new Three.js BufferGeometry
+ * @throws Error if Three.js is not installed
+ *
+ * @example
+ * ```typescript
+ * import { toThreeGeometry } from 'mmg-wasm/three';
+ *
+ * const result = await mesh.remesh({ hmax: 0.1 });
+ * const geometry = await toThreeGeometry(result.mesh);
+ *
+ * // Use in Three.js scene
+ * const material = new THREE.MeshStandardMaterial({ color: 0x00ff00 });
+ * const threeMesh = new THREE.Mesh(geometry, material);
+ * scene.add(threeMesh);
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Skip normal computation
+ * const geometry = await toThreeGeometry(mesh, { computeNormals: false });
+ * ```
+ */
+export async function toThreeGeometry(
+  mesh: Mesh,
+  options: ToThreeOptions = {},
+): Promise<BufferGeometry> {
+  const { computeNormals = true } = options;
+
+  // Dynamic import of Three.js to avoid bundling if not used
+  let THREE: typeof import("three");
+  try {
+    THREE = await import("three");
+  } catch {
+    throw new Error(
+      "Three.js is not installed. Install it with: npm install three",
+    );
+  }
+
+  const geometry = new THREE.BufferGeometry();
+
+  // Get mesh data
+  const vertices = mesh.vertices;
+  const dimension = mesh.dimension;
+
+  // For volumetric meshes, use boundary faces for visualization
+  // For surface/2D meshes, use the cells directly
+  let triangleIndices: Int32Array;
+  if (mesh.type === MeshType.Mesh3D) {
+    // Extract boundary triangles for volumetric meshes
+    triangleIndices = mesh.boundaryFaces;
+  } else {
+    triangleIndices = mesh.cells;
+  }
+
+  // Convert vertices from Float64 to Float32 (WebGL requirement)
+  // Also handle 2D vertices by adding z=0
+  let positions: Float32Array;
+  if (dimension === 2) {
+    // 2D mesh: add z=0 for each vertex
+    const nVertices = vertices.length / 2;
+    positions = new Float32Array(nVertices * 3);
+    for (let i = 0; i < nVertices; i++) {
+      positions[i * 3] = vertices[i * 2];
+      positions[i * 3 + 1] = vertices[i * 2 + 1];
+      positions[i * 3 + 2] = 0;
+    }
+  } else {
+    // 3D mesh: direct conversion
+    positions = new Float32Array(vertices.length);
+    for (let i = 0; i < vertices.length; i++) {
+      positions[i] = vertices[i];
+    }
+  }
+
+  geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+
+  // Convert 1-indexed cells to 0-indexed for Three.js
+  const indices: number[] = [];
+  for (let i = 0; i < triangleIndices.length; i++) {
+    indices.push(triangleIndices[i] - 1);
+  }
+  geometry.setIndex(indices);
+
+  // Compute normals if requested
+  if (computeNormals) {
+    geometry.computeVertexNormals();
+  }
+
+  return geometry;
+}
+
+/**
+ * Synchronous version of toThreeGeometry for use when Three.js is already imported
+ *
+ * This function requires Three.js to be passed as a parameter, avoiding the async import.
+ * Use this when you already have Three.js loaded and want synchronous conversion.
+ *
+ * @param mesh - The mmg-wasm Mesh to convert
+ * @param THREE - The Three.js module
+ * @param options - Conversion options
+ * @returns A new Three.js BufferGeometry
+ *
+ * @example
+ * ```typescript
+ * import * as THREE from 'three';
+ * import { toThreeGeometrySync } from 'mmg-wasm/three';
+ *
+ * const geometry = toThreeGeometrySync(mesh, THREE);
+ * ```
+ */
+export function toThreeGeometrySync(
+  mesh: Mesh,
+  THREE: typeof import("three"),
+  options: ToThreeOptions = {},
+): BufferGeometry {
+  const { computeNormals = true } = options;
+
+  const geometry = new THREE.BufferGeometry();
+
+  // Get mesh data
+  const vertices = mesh.vertices;
+  const dimension = mesh.dimension;
+
+  // For volumetric meshes, use boundary faces for visualization
+  let triangleIndices: Int32Array;
+  if (mesh.type === MeshType.Mesh3D) {
+    triangleIndices = mesh.boundaryFaces;
+  } else {
+    triangleIndices = mesh.cells;
+  }
+
+  // Convert vertices from Float64 to Float32
+  let positions: Float32Array;
+  if (dimension === 2) {
+    const nVertices = vertices.length / 2;
+    positions = new Float32Array(nVertices * 3);
+    for (let i = 0; i < nVertices; i++) {
+      positions[i * 3] = vertices[i * 2];
+      positions[i * 3 + 1] = vertices[i * 2 + 1];
+      positions[i * 3 + 2] = 0;
+    }
+  } else {
+    positions = new Float32Array(vertices.length);
+    for (let i = 0; i < vertices.length; i++) {
+      positions[i] = vertices[i];
+    }
+  }
+
+  geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+
+  // Convert 1-indexed to 0-indexed
+  const indices: number[] = [];
+  for (let i = 0; i < triangleIndices.length; i++) {
+    indices.push(triangleIndices[i] - 1);
+  }
+  geometry.setIndex(indices);
+
+  if (computeNormals) {
+    geometry.computeVertexNormals();
+  }
+
+  return geometry;
+}

--- a/test/three.test.ts
+++ b/test/three.test.ts
@@ -1,0 +1,381 @@
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
+import * as THREE from "three";
+import { Mesh, MeshType, initMMG2D, initMMG3D, initMMGS } from "../src";
+import {
+	fromThreeGeometry,
+	toThreeGeometry,
+	toThreeGeometrySync,
+} from "../src/three";
+import { cubeTetrahedra, cubeTriangles, cubeVertices } from "./fixtures/cube";
+import { squareEdges, squareTriangles, squareVertices } from "./fixtures/square";
+
+describe("Three.js Integration", () => {
+	const meshes: Mesh[] = [];
+	const geometries: THREE.BufferGeometry[] = [];
+
+	beforeAll(async () => {
+		await initMMG2D();
+		await initMMG3D();
+		await initMMGS();
+	});
+
+	afterEach(() => {
+		for (const mesh of meshes) {
+			try {
+				mesh.free();
+			} catch {
+				// Ignore errors from already-freed meshes
+			}
+		}
+		meshes.length = 0;
+
+		for (const geometry of geometries) {
+			geometry.dispose();
+		}
+		geometries.length = 0;
+	});
+
+	describe("fromThreeGeometry", () => {
+		it("should convert indexed BoxGeometry to surface mesh", () => {
+			const boxGeometry = new THREE.BoxGeometry(1, 1, 1);
+			geometries.push(boxGeometry);
+
+			const mesh = fromThreeGeometry(boxGeometry);
+			meshes.push(mesh);
+
+			expect(mesh.type).toBe(MeshType.MeshS);
+			expect(mesh.dimension).toBe(3);
+			expect(mesh.nVertices).toBe(boxGeometry.attributes.position.count);
+			// BoxGeometry has 6 faces * 2 triangles = 12 triangles
+			expect(mesh.nCells).toBe(12);
+		});
+
+		it("should convert SphereGeometry to surface mesh", () => {
+			const sphereGeometry = new THREE.SphereGeometry(1, 8, 6);
+			geometries.push(sphereGeometry);
+
+			const mesh = fromThreeGeometry(sphereGeometry);
+			meshes.push(mesh);
+
+			expect(mesh.type).toBe(MeshType.MeshS);
+			expect(mesh.nVertices).toBeGreaterThan(0);
+			expect(mesh.nCells).toBeGreaterThan(0);
+		});
+
+		it("should convert PlaneGeometry to surface mesh by default", () => {
+			const planeGeometry = new THREE.PlaneGeometry(1, 1);
+			geometries.push(planeGeometry);
+
+			const mesh = fromThreeGeometry(planeGeometry);
+			meshes.push(mesh);
+
+			// PlaneGeometry has 3D vertices, so it's a surface mesh
+			expect(mesh.type).toBe(MeshType.MeshS);
+			expect(mesh.nVertices).toBe(4);
+			expect(mesh.nCells).toBe(2);
+		});
+
+		it("should force mesh type with options", () => {
+			const boxGeometry = new THREE.BoxGeometry(1, 1, 1);
+			geometries.push(boxGeometry);
+
+			const mesh = fromThreeGeometry(boxGeometry, { type: MeshType.MeshS });
+			meshes.push(mesh);
+
+			expect(mesh.type).toBe(MeshType.MeshS);
+		});
+
+		it("should handle non-indexed geometry", () => {
+			// Create a non-indexed geometry
+			const geometry = new THREE.BufferGeometry();
+			const vertices = new Float32Array([
+				0, 0, 0, 1, 0, 0, 0.5, 1, 0, 1, 0, 0, 2, 0, 0, 1.5, 1, 0,
+			]);
+			geometry.setAttribute("position", new THREE.BufferAttribute(vertices, 3));
+			geometries.push(geometry);
+
+			const mesh = fromThreeGeometry(geometry);
+			meshes.push(mesh);
+
+			expect(mesh.type).toBe(MeshType.MeshS);
+			expect(mesh.nVertices).toBe(6);
+			expect(mesh.nCells).toBe(2);
+		});
+
+		it("should throw for geometry without position attribute", () => {
+			const geometry = new THREE.BufferGeometry();
+			geometries.push(geometry);
+
+			expect(() => fromThreeGeometry(geometry)).toThrow(
+				/must have a position attribute/,
+			);
+		});
+
+		it("should throw for geometry with less than 3 vertices", () => {
+			const geometry = new THREE.BufferGeometry();
+			const vertices = new Float32Array([0, 0, 0, 1, 0, 0]);
+			geometry.setAttribute("position", new THREE.BufferAttribute(vertices, 3));
+			geometries.push(geometry);
+
+			expect(() => fromThreeGeometry(geometry)).toThrow(/at least 3 vertices/);
+		});
+
+		it("should convert 1-indexed cells correctly", () => {
+			const boxGeometry = new THREE.BoxGeometry(1, 1, 1);
+			geometries.push(boxGeometry);
+
+			const mesh = fromThreeGeometry(boxGeometry);
+			meshes.push(mesh);
+
+			// Check that cells are 1-indexed (MMG convention)
+			const cells = mesh.cells;
+			const minIndex = Math.min(...cells);
+			expect(minIndex).toBeGreaterThanOrEqual(1);
+		});
+	});
+
+	describe("toThreeGeometry", () => {
+		it("should convert surface mesh to BufferGeometry", async () => {
+			const mesh = new Mesh({
+				vertices: cubeVertices,
+				cells: cubeTriangles,
+				type: MeshType.MeshS,
+			});
+			meshes.push(mesh);
+
+			const geometry = await toThreeGeometry(mesh);
+			geometries.push(geometry);
+
+			expect(geometry).toBeInstanceOf(THREE.BufferGeometry);
+			expect(geometry.attributes.position).toBeDefined();
+			expect(geometry.index).toBeDefined();
+
+			// Check vertex count matches
+			expect(geometry.attributes.position.count).toBe(mesh.nVertices);
+
+			// Check that normals were computed
+			expect(geometry.attributes.normal).toBeDefined();
+		});
+
+		it("should convert 3D volumetric mesh using boundary faces", async () => {
+			const mesh = new Mesh({
+				vertices: cubeVertices,
+				cells: cubeTetrahedra,
+				boundaryFaces: cubeTriangles,
+			});
+			meshes.push(mesh);
+
+			const geometry = await toThreeGeometry(mesh);
+			geometries.push(geometry);
+
+			expect(geometry.attributes.position.count).toBe(mesh.nVertices);
+			// Index count should match boundary triangles count * 3
+			expect(geometry.index?.count).toBe(mesh.nBoundaryFaces * 3);
+		});
+
+		it("should convert 2D mesh with z=0", async () => {
+			const mesh = new Mesh({
+				vertices: squareVertices,
+				cells: squareTriangles,
+				boundaryFaces: squareEdges,
+			});
+			meshes.push(mesh);
+
+			const geometry = await toThreeGeometry(mesh);
+			geometries.push(geometry);
+
+			// 2D mesh should have 3D positions with z=0
+			const positions = geometry.attributes.position;
+			expect(positions.count).toBe(mesh.nVertices);
+			expect(positions.itemSize).toBe(3);
+
+			// Check that all z values are 0
+			for (let i = 0; i < positions.count; i++) {
+				expect(positions.getZ(i)).toBe(0);
+			}
+		});
+
+		it("should skip normal computation when disabled", async () => {
+			const mesh = new Mesh({
+				vertices: cubeVertices,
+				cells: cubeTriangles,
+				type: MeshType.MeshS,
+			});
+			meshes.push(mesh);
+
+			const geometry = await toThreeGeometry(mesh, { computeNormals: false });
+			geometries.push(geometry);
+
+			expect(geometry.attributes.normal).toBeUndefined();
+		});
+
+		it("should convert indices to 0-indexed", async () => {
+			const mesh = new Mesh({
+				vertices: cubeVertices,
+				cells: cubeTriangles,
+				type: MeshType.MeshS,
+			});
+			meshes.push(mesh);
+
+			const geometry = await toThreeGeometry(mesh);
+			geometries.push(geometry);
+
+			// Check that indices are 0-indexed (Three.js convention)
+			const index = geometry.index;
+			if (index) {
+				const minIndex = Math.min(...index.array);
+				expect(minIndex).toBe(0);
+			}
+		});
+	});
+
+	describe("toThreeGeometrySync", () => {
+		it("should convert mesh synchronously", () => {
+			const mesh = new Mesh({
+				vertices: cubeVertices,
+				cells: cubeTriangles,
+				type: MeshType.MeshS,
+			});
+			meshes.push(mesh);
+
+			const geometry = toThreeGeometrySync(mesh, THREE);
+			geometries.push(geometry);
+
+			expect(geometry).toBeInstanceOf(THREE.BufferGeometry);
+			expect(geometry.attributes.position.count).toBe(mesh.nVertices);
+		});
+
+		it("should match async version output", async () => {
+			const mesh = new Mesh({
+				vertices: cubeVertices,
+				cells: cubeTriangles,
+				type: MeshType.MeshS,
+			});
+			meshes.push(mesh);
+
+			const asyncGeometry = await toThreeGeometry(mesh);
+			const syncGeometry = toThreeGeometrySync(mesh, THREE);
+			geometries.push(asyncGeometry, syncGeometry);
+
+			// Compare positions
+			const asyncPositions = asyncGeometry.attributes.position;
+			const syncPositions = syncGeometry.attributes.position;
+
+			expect(syncPositions.count).toBe(asyncPositions.count);
+			for (let i = 0; i < asyncPositions.count; i++) {
+				expect(syncPositions.getX(i)).toBe(asyncPositions.getX(i));
+				expect(syncPositions.getY(i)).toBe(asyncPositions.getY(i));
+				expect(syncPositions.getZ(i)).toBe(asyncPositions.getZ(i));
+			}
+		});
+	});
+
+	describe("Round-trip conversion", () => {
+		it("should preserve vertex count in Three.js -> mmg -> Three.js", async () => {
+			const boxGeometry = new THREE.BoxGeometry(1, 1, 1);
+			geometries.push(boxGeometry);
+
+			const originalVertexCount = boxGeometry.attributes.position.count;
+
+			// Convert to mmg-wasm
+			const mesh = fromThreeGeometry(boxGeometry);
+			meshes.push(mesh);
+
+			// Convert back to Three.js
+			const resultGeometry = await toThreeGeometry(mesh);
+			geometries.push(resultGeometry);
+
+			expect(resultGeometry.attributes.position.count).toBe(originalVertexCount);
+		});
+
+		it("should preserve triangle count in round-trip", async () => {
+			const sphereGeometry = new THREE.SphereGeometry(1, 16, 12);
+			geometries.push(sphereGeometry);
+
+			const originalTriangles = sphereGeometry.index
+				? sphereGeometry.index.count / 3
+				: sphereGeometry.attributes.position.count / 3;
+
+			const mesh = fromThreeGeometry(sphereGeometry);
+			meshes.push(mesh);
+
+			const resultGeometry = await toThreeGeometry(mesh);
+			geometries.push(resultGeometry);
+
+			const resultTriangles = resultGeometry.index
+				? resultGeometry.index.count / 3
+				: resultGeometry.attributes.position.count / 3;
+
+			expect(resultTriangles).toBe(originalTriangles);
+		});
+
+		it("should allow remeshing and conversion back", async () => {
+			const boxGeometry = new THREE.BoxGeometry(1, 1, 1);
+			geometries.push(boxGeometry);
+
+			// Convert to mmg-wasm
+			const mesh = fromThreeGeometry(boxGeometry);
+			meshes.push(mesh);
+
+			// Remesh with finer resolution
+			const result = await mesh.remesh({ hmax: 0.2 });
+			meshes.push(result.mesh);
+
+			expect(result.success).toBe(true);
+			expect(result.nVertices).toBeGreaterThan(mesh.nVertices);
+
+			// Convert back to Three.js
+			const resultGeometry = await toThreeGeometry(result.mesh);
+			geometries.push(resultGeometry);
+
+			expect(resultGeometry.attributes.position.count).toBe(result.nVertices);
+		});
+	});
+
+	describe("Integration with local refinement", () => {
+		it("should support local refinement workflow", async () => {
+			const boxGeometry = new THREE.BoxGeometry(1, 1, 1);
+			geometries.push(boxGeometry);
+
+			// Convert to mmg-wasm
+			const mesh = fromThreeGeometry(boxGeometry);
+			meshes.push(mesh);
+
+			// Add local refinement
+			mesh.setSizeSphere([0, 0, 0], 0.3, 0.05);
+
+			// Remesh
+			const result = await mesh.remesh();
+			meshes.push(result.mesh);
+
+			expect(result.success).toBe(true);
+
+			// Convert back
+			const resultGeometry = await toThreeGeometry(result.mesh);
+			geometries.push(resultGeometry);
+
+			expect(resultGeometry.attributes.position).toBeDefined();
+		});
+	});
+
+	describe("Float64 to Float32 precision", () => {
+		it("should handle typical geometry coordinates", () => {
+			// Test with coordinates that are typical for 3D models
+			const geometry = new THREE.BufferGeometry();
+			const vertices = new Float32Array([
+				-100.5, 200.25, 50.125, 100.5, -200.25, -50.125, 0.001, 0.001, 0.001,
+			]);
+			geometry.setAttribute("position", new THREE.BufferAttribute(vertices, 3));
+			geometries.push(geometry);
+
+			const mesh = fromThreeGeometry(geometry);
+			meshes.push(mesh);
+
+			// Verify coordinates are preserved within float32 precision
+			const meshVertices = mesh.vertices;
+			expect(Math.abs(meshVertices[0] - -100.5)).toBeLessThan(0.001);
+			expect(Math.abs(meshVertices[1] - 200.25)).toBeLessThan(0.001);
+			expect(Math.abs(meshVertices[6] - 0.001)).toBeLessThan(0.0001);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Add `fromThreeGeometry()` to convert Three.js BufferGeometry to mmg-wasm Mesh
- Add `toThreeGeometry()` (async) and `toThreeGeometrySync()` to convert mmg-wasm Mesh back to BufferGeometry
- Configure Three.js as optional peer dependency

## Changes
- `src/three/index.ts`: New module with conversion utilities
- `src/index.ts`: Export Three.js utilities from main entry point
- `test/three.test.ts`: Comprehensive tests for all conversion scenarios
- `package.json`: Add Three.js as optional peer dependency with types

## Features
- Handle indexed and non-indexed geometries
- Convert between 0-indexed (Three.js) and 1-indexed (MMG) cells
- Convert Float32 (WebGL) ↔ Float64 (mmg) with proper precision
- Support 2D meshes by adding z=0 for Three.js compatibility
- Extract boundary faces for volumetric mesh visualization
- Optional vertex normal computation (enabled by default)

## Test plan
- [x] Convert BoxGeometry to Mesh and back
- [x] Handle non-indexed geometries
- [x] Round-trip conversion preserves vertex/triangle counts
- [x] Remesh workflow with Three.js integration
- [x] Local refinement workflow
- [x] Float precision handling

Closes #22