### PR TITLE
Fix remaining code quality issues from review

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -163,14 +163,15 @@ The global `modulePromise` check at line 14 has no lock. Multiple React componen
 
 **Fix:** Simplified to a single promise variable with the same lazy singleton pattern as 4.2. The redundant `moduleInstance` variable was removed.
 
-### 4.4 Worker Cancellation Cannot Interrupt WASM
+### 4.4 Worker Cancellation Cannot Interrupt WASM — ✅ Resolved (documented)
 
 **File:** `src/worker/remesh.worker.ts:104-105`
 **Severity:** MEDIUM
+**Status:** Documented in `fix/code-quality-issues` branch
 
 The `cancel()` method sets a `cancelled` flag, but once MMG's C code is executing in WASM, there is no way to interrupt it. The flag is only checked between JavaScript operations, not during the remeshing computation itself. Users may expect cancellation to be immediate.
 
-**Fix:** Document this limitation clearly. Consider adding a timeout mechanism that terminates and recreates the worker if cancellation is needed during a long-running operation.
+**Fix:** Added JSDoc to `handleRemesh` and `handleCancel` documenting cooperative cancellation semantics.
 
 ---
 
@@ -182,22 +183,22 @@ The `cancel()` method sets a `cancelled` flag, but once MMG's C code is executin
 |-------|----------|----------|
 | `Math.max(...cells)` stack overflow | `mesh.ts:1138` | High |
 | Unchecked intermediate malloc | `mmg3d.ts:465-471` | Medium |
-| FS temp file cleanup on error | `mesh.ts:205-229` | Low |
+| FS temp file cleanup on error | `mesh.ts:205-229` | Low | ✅ Fixed |
 
 ### Error Handling
 
 | Issue | Location | Severity |
 |-------|----------|----------|
 | Empty mesh not validated in constructor | `mesh.ts:156-160` | Medium |
-| `vertexDim - 2 < 0.01` tolerance in type detection | `mesh.ts:1146` | Medium |
-| Ambiguous cancel behavior when id is undefined | `worker/remesh.worker.ts:216-219` | Low |
+| `vertexDim - 2 < 0.01` tolerance in type detection | `mesh.ts:1146` | Medium | ✅ Fixed |
+| Ambiguous cancel behavior when id is undefined | `worker/remesh.worker.ts:216-219` | Low | ✅ Documented |
 
 ### Concurrency
 
 | Issue | Location | Severity |
 |-------|----------|----------|
 | Module init race condition | `mesh.ts:90-92` | High |
-| Worker cancellation race | `worker/remesh.worker.ts:104-105` | Medium |
+| Worker cancellation race | `worker/remesh.worker.ts:104-105` | Medium | ✅ Documented |
 | Demo module singleton race | `web/src/hooks/useMmgWasm.ts:9-24` | Medium |
 
 ### Web Demo
@@ -213,7 +214,7 @@ The `cancel()` method sets a `cancelled` flag, but once MMG's C code is executin
 | Issue | Location | Severity |
 |-------|----------|----------|
 | `Math.max(...cells)` for large arrays | `mesh.ts:1138` | High |
-| `number[]` intermediate in Three.js index conversion | `three/index.ts:254-258` | Low |
+| `number[]` intermediate in Three.js index conversion | `three/index.ts:254-258` | Low | ✅ Fixed |
 | Repeated vertex iteration in `computeDefaultSize` | `mesh.ts:1074-1084` | Low |
 
 ### Build Configuration

--- a/src/mesh.ts
+++ b/src/mesh.ts
@@ -1145,25 +1145,28 @@ export class Mesh {
     // vertices.length = nVertices * dimension
     // So dimension = vertices.length / nVertices
     const vertexDim = vertices.length / maxVertexIndex;
+    const roundedDim = Math.round(vertexDim);
 
-    // Check if it's exactly 2 or 3
-    if (Math.abs(vertexDim - 2) < 0.01) {
-      // 2D mesh
+    if (
+      roundedDim < 2 ||
+      roundedDim > 3 ||
+      vertices.length % maxVertexIndex !== 0
+    ) {
+      throw new Error(
+        `Cannot auto-detect mesh type: vertex count (${vertices.length}) is not evenly divisible by max vertex index (${maxVertexIndex})`,
+      );
+    }
+
+    if (roundedDim === 2) {
       return MeshType.Mesh2D;
     }
 
-    if (Math.abs(vertexDim - 3) < 0.01) {
-      // 3D mesh - now determine if volume (tetrahedra) or surface (triangles)
-      const cellSize = Mesh.guessCellSize(cells, maxVertexIndex);
-      if (cellSize === 4) {
-        return MeshType.Mesh3D;
-      }
-      return MeshType.MeshS;
+    // 3D: determine if volume (tetrahedra) or surface (triangles)
+    const cellSize = Mesh.guessCellSize(cells, maxVertexIndex);
+    if (cellSize === 4) {
+      return MeshType.Mesh3D;
     }
-
-    throw new Error(
-      `Cannot auto-detect mesh type: computed vertexDim=${vertexDim.toFixed(2)}`,
-    );
+    return MeshType.MeshS;
   }
 
   /**

--- a/src/mesh.ts
+++ b/src/mesh.ts
@@ -206,9 +206,9 @@ export class Mesh {
     const FS = Mesh.getFS(type);
     const filename = `/input.${format}`;
 
-    FS.writeFile(filename, buffer);
-
     try {
+      FS.writeFile(filename, buffer);
+
       const mesh = new Mesh({
         vertices: new Float64Array(0),
         cells: new Int32Array(0),

--- a/src/three/index.ts
+++ b/src/three/index.ts
@@ -251,11 +251,11 @@ export async function toThreeGeometry(
   geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
 
   // Convert 1-indexed cells to 0-indexed for Three.js
-  const indices: number[] = [];
+  const indices = new Uint32Array(triangleIndices.length);
   for (let i = 0; i < triangleIndices.length; i++) {
-    indices.push(triangleIndices[i] - 1);
+    indices[i] = triangleIndices[i] - 1;
   }
-  geometry.setIndex(indices);
+  geometry.setIndex(new THREE.BufferAttribute(indices, 1));
 
   // Compute normals if requested
   if (computeNormals) {
@@ -325,11 +325,11 @@ export function toThreeGeometrySync(
   geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
 
   // Convert 1-indexed to 0-indexed
-  const indices: number[] = [];
+  const indices = new Uint32Array(triangleIndices.length);
   for (let i = 0; i < triangleIndices.length; i++) {
-    indices.push(triangleIndices[i] - 1);
+    indices[i] = triangleIndices[i] - 1;
   }
-  geometry.setIndex(indices);
+  geometry.setIndex(new THREE.BufferAttribute(indices, 1));
 
   if (computeNormals) {
     geometry.computeVertexNormals();

--- a/src/worker/remesh.worker.ts
+++ b/src/worker/remesh.worker.ts
@@ -95,6 +95,11 @@ function serializeMesh(mesh: Mesh): SerializedMeshData {
 
 /**
  * Handle remesh request
+ *
+ * Cancellation is cooperative: the `cancelled` flag is only checked between
+ * JavaScript stages (module init, mesh creation, post-remesh extraction).
+ * Once the WASM remeshing computation begins (`mesh.remesh()`), it cannot
+ * be interrupted until it returns.
  */
 async function handleRemesh(
   id: string,
@@ -212,6 +217,9 @@ async function handleRemesh(
 
 /**
  * Handle cancel request
+ *
+ * If `id` is `undefined`, cancels whatever operation is currently running.
+ * If `id` matches the current operation, cancels that specific operation.
  */
 function handleCancel(id?: string): void {
   if (id === undefined || id === currentOperationId) {


### PR DESCRIPTION
## Summary

- Use `Uint32Array` + `BufferAttribute` for Three.js index conversion instead of `number[]` with push-per-element
- Replace arbitrary `0.01` tolerance in mesh type detection with exact integer divisibility check
- Add JSDoc to worker `handleRemesh` and `handleCancel` documenting cooperative cancellation semantics
- Move `FS.writeFile` inside try block in `Mesh.load` for consistent file cleanup
- Update REVIEW.md to reflect resolved items

## Test plan

- [x] `bun test` — 372 tests pass
- [x] `bun run check` — Biome lint and format clean
- [x] `bun run typecheck` — TypeScript strict mode passes